### PR TITLE
use axios

### DIFF
--- a/lib/handsoap.js
+++ b/lib/handsoap.js
@@ -1,8 +1,8 @@
-const request = require('request');
+const axios = require('axios');
 const XML = require('./xml');
 const zlib = require('zlib');
 const chalk = require('chalk');
- 
+
 class HandSoap {
   request(url, operation, action, body, options, auth) {
     return new Promise((resolve, reject) => {
@@ -11,35 +11,33 @@ class HandSoap {
 
       const requestOptions = {
         url,
-        body: xml,
-        headers: this.headers(action, xml.length, httpHeaders)
+        headers: this.headers(action, xml.length, httpHeaders),
+        validateStatus: (status) => { return status == 200 }
       };
 
       if (typeof auth !== 'undefined') {
         requestOptions.auth = {
-          user: auth.user || auth.username,
-          pass: auth.pass || auth.password
+          username: auth.user || auth.username,
+          password: auth.pass || auth.password
         }
       }
 
-      const req = request.post(requestOptions, (err, response, body) => {
-        if (err || response.statusCode !== 200) {
-          const error = err ?
-            err : chalk.red(`
-              ERROR
-              =================
-              Http Status code: ${response.statusCode}
-              =================
-              Response: ${JSON.stringify(response)}
-              =================
-              Body: ${body}`);
-          reject(error);
-          return;
-        }
-
-        resolve(XML.parse(body));
+      const req = axios.post(url, xml, requestOptions)
+      .then((res) => {
+        resolve(XML.parse(res.data));
+      }).catch((err) => {
+        const error = err ?
+          err : chalk.red(`
+            ERROR
+            =================
+            Http Status code: ${err.response.statusCode}
+            =================
+            Response: ${JSON.stringify(err.response)}
+            =================
+            Body: ${err.response.data}`);
+        reject(error);
       });
-    })
+    });
   }
 
   envelope(operation, body, options) {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "author": "Vitaliy Isikov",
   "license": "MIT",
   "dependencies": {
+    "axios": "^0.17.1",
     "chalk": "^1.1.3",
-    "request": "2.79.0",
     "xml2js": "0.4.17"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace 'request' module to 'axios'.

If you bundle to browser, you get large file from node builtin shims with request about 2.2MB. Replacing request to axios, you can lose approx. 1.5kB.